### PR TITLE
Prevent re-creation of empty submission after cancel.

### DIFF
--- a/QuickSubmitPlugin.inc.php
+++ b/QuickSubmitPlugin.inc.php
@@ -108,8 +108,8 @@ class QuickSubmitPlugin extends ImportExportPlugin {
 		$notificationMgr = new NotificationManager();
 		$notificationMgr->createTrivialNotification($currentUser->getId(), NOTIFICATION_TYPE_SUCCESS, array('contents' => $notificationContent));
 
-		$path = array('plugin', $this->getName());
-		$request->redirect(null, null, null, $path, null, null);
+		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr->display($this->getTemplatePath() . 'submitCancel.tpl');
 	}
 
 	/**

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -18,6 +18,8 @@
 	<message key="plugins.importexport.quickSubmit.success">Article Added</message>
 	<message key="plugins.importexport.quickSubmit.successDescription">Article creation was successful.</message>
 	<message key="plugins.importexport.quickSubmit.successReturn">Return to QuickSubmit plugin.</message>
+	<message key="plugins.importexport.quickSubmit.cancel">Submission cancelled</message>
+	<message key="plugins.importexport.quickSubmit.cancelDescription">Submission was cancelled.</message>
 	<message key="plugins.importexport.quickSubmit.published">Published</message>
 	<message key="plugins.importexport.quickSubmit.unpublished">Unpublished</message>
 	<message key="plugins.importexport.quickSubmit.goToSubmission">Go to Submission</message>

--- a/templates/submitCancel.tpl
+++ b/templates/submitCancel.tpl
@@ -1,0 +1,27 @@
+{**
+ * plugins/importexport/quickSubmit/templates/submitCancel.tpl
+ *
+ * Copyright (c) 2013-2018 Simon Fraser University
+ * Copyright (c) 2003-2018 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Display a message indicating that the submission was cancelled.
+ *
+ *}
+{strip}
+{assign var="pageTitle" value="plugins.importexport.quickSubmit.cancel"}
+{include file="common/header.tpl"}
+{/strip}
+
+<div class="pkp_page_content pkp_cancelQuickSubmit">
+	<p>
+		{translate key="plugins.importexport.quickSubmit.cancelDescription"}  
+	</p>
+	<p> 
+		<a href="{plugin_url}">
+			{translate key="plugins.importexport.quickSubmit.successReturn"}
+		</a>
+	</p>
+</div>
+
+{include file="common/footer.tpl"}


### PR DESCRIPTION
See: https://forum.pkp.sfu.ca/t/quicksubmit-plugin-leaves-incomplete-submission-if-canceled/50626

