### PR TITLE
Align register() and smartyPluginUrl() signatures with 3.1.2

### DIFF
--- a/QuickSubmitPlugin.inc.php
+++ b/QuickSubmitPlugin.inc.php
@@ -21,14 +21,14 @@ class QuickSubmitPlugin extends ImportExportPlugin {
 	/**
 	 * @copydoc Plugin::register()
 	 */
-	function register($category, $path) {
+	function register($category, $path, $mainContextId = NULL) {
 		AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON,
 			LOCALE_COMPONENT_APP_SUBMISSION,
 			LOCALE_COMPONENT_APP_AUTHOR,
 			LOCALE_COMPONENT_APP_EDITOR,
 			LOCALE_COMPONENT_PKP_SUBMISSION);
 
-		$success = parent::register($category, $path);
+		$success = parent::register($category, $path, $mainContextId);
 		$this->addLocaleData();
 
 		return $success;
@@ -208,7 +208,7 @@ class QuickSubmitPlugin extends ImportExportPlugin {
 	/**
 	 * Extend the {url ...} for smarty to support this plugin.
 	 */
-	function smartyPluginUrl($params, &$smarty) {
+	function smartyPluginUrl($params, $smarty) {
 		$path = array('plugin',$this->getName());
 		if (is_array($params['path'])) {
 			$params['path'] = array_merge($path, $params['path']);


### PR DESCRIPTION
`LazyLoadPlugin::register()` [was modified in 3.1.1](https://github.com/pkp/pkp-lib/commit/c3a8f6eecdf2a8c8f5b894643d75459ca4e97ff8#diff-c4d29e88562e533ce6d082d439363531).
`Plugin::smartyPluginUrl()` [was modified in 3.1.2](https://github.com/pkp/pkp-lib/commit/94fb8229ba1d1bb821fa494e7fc50095d7ac2698#diff-6ab0758a979d98dfd8005e5cc0a077bd)
